### PR TITLE
Check for the correct error in get_park_boundaries

### DIFF
--- a/R/shapefile.R
+++ b/R/shapefile.R
@@ -92,10 +92,10 @@ get_park_boundaries <- function(parkname, local_dir = tempdir()) {
     # If not, it could be a spelling error. Make suggestions.
     best_matches <- suggest_parkname(parkname, avail_names)
     best_matches <- paste(best_matches, collapse = "\n")
-    msg <- paste0("The requested park (", parkname, ") is not contained in ",
-                 "the national park boundary data. Here are the top five ",
+    msg <- paste("The requested park (", parkname, ") is not contained in",
+                 "the national park boundary data. Here are the top five",
                  "matches:\n", best_matches, "\n")
-    stop(cat(msg))
+    stop(msg)
   }
 
   aoi <- parks[grepl(parkname, parks$UNIT_NAME), ]

--- a/tests/testthat/test-shapefile.R
+++ b/tests/testthat/test-shapefile.R
@@ -5,8 +5,8 @@ test_that("Test download_shapefile for file and shapefile object", {
     dir <- tempdir()
     path <- file.path(dir, "shapefiles", "tl_2019_44_cousub",
                       "tl_2019_44_cousub.shp")
-    
-    aoi <- get_shapefile(path = url, 
+
+    aoi <- get_shapefile(path = url,
                          local_dir = dir)
 
     expect_true(file.exists(path))
@@ -15,13 +15,13 @@ test_that("Test download_shapefile for file and shapefile object", {
 
 test_that("Test get_park_boundaries for file and shapefile object", {
   clean_up <- function() {
-    unlink(list.files(pattern = "nps_boundary", 
-                      recursive = TRUE, 
-                      full.names = TRUE, 
-                      include.dirs = TRUE), 
+    unlink(list.files(pattern = "nps_boundary",
+                      recursive = TRUE,
+                      full.names = TRUE,
+                      include.dirs = TRUE),
            force = TRUE, recursive = TRUE) # ensure no previous files
   }
-  
+
   parkname <- "Yellowstone National Park"
 
   dir <- "."
@@ -45,5 +45,6 @@ test_that("Local shapefiles are readable", {
 })
 
 test_that("Invalid park names raise errors", {
-  expect_error(get_park_boundaries("Poodlebear National Park"))
+  expect_error(get_park_boundaries("Poodlebear National Park"),
+               regexp = "is not contained in the national park boundary data")
 })


### PR DESCRIPTION
@WilliamsTravis wherever we have an `expect_error` in the tests, we should use the `regexp` argument to ensure that we get the right error message. Otherwise there can be weird cases where you get an error, but not the one you expect, and the test still passes. 

Closes #35 